### PR TITLE
maps/map-deletion: focus only on map clearing

### DIFF
--- a/maps/map-deletion/bench_test.go
+++ b/maps/map-deletion/bench_test.go
@@ -2,15 +2,13 @@ package mapclearing
 
 import "testing"
 
-func returnValuesAndClearMap(m map[int]int) (values []int) {
-	values = make([]int, len(m))
+func returnValuesAndClearMap(m map[int]int) int {
 	i := 0
 	for key, value := range m {
 		delete(m, key)
-		values[i] = value
-		i++
+		i += value
 	}
-	return values
+	return i
 }
 
 func populateMap(n int) map[int]int {


### PR DESCRIPTION
To eliminate noise from allocations per se for the values slice,
so that we can focus on examining the performance of actual map
clearing.